### PR TITLE
Add CPU entry point for Stable-Baselines3 training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ imageio
 pillow
 pygame
 scikit-learn
+gymnasium
+stable-baselines3

--- a/rl_play.py
+++ b/rl_play.py
@@ -1,0 +1,131 @@
+"""Collect winning trajectories from a trained RL agent.
+
+This utility mirrors :mod:`play` but drives the environment with a
+Stable-Baselines3 policy instead of human keyboard input.  Every time the agent
+wins a game the observation-action history is dumped to
+``logs/game_records_lvl{level}_{timestamp}/data.pkl`` so that the resulting data
+matches the format produced by manual play sessions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pickle
+from typing import List, Tuple
+
+from env import AliensEnv
+from train_rl_agent import encode_observation, set_global_seeds
+
+try:  # Stable-Baselines3 is required to load and run the trained policy.
+    from stable_baselines3 import DQN
+except ImportError as exc:  # pragma: no cover - more informative error message.
+    raise ImportError(
+        "stable-baselines3 is required. Install the optional dependencies with"
+        " `pip install -r requirements.txt`."
+    ) from exc
+
+
+class AliensEnvRecorder(AliensEnv):
+    """Aliens environment variant that creates log folders on reset."""
+
+    def __init__(self, level: int = 0, render: bool = False):
+        super().__init__(level=level, render=render)
+        self._update_log_folder()
+
+    def _update_log_folder(self) -> None:
+        self.log_folder = f"logs/game_records_lvl{self.level}_{self.timing}"
+        os.makedirs(self.log_folder, exist_ok=True)
+
+    def reset(self):  # type: ignore[override]
+        observation = super().reset()
+        self._update_log_folder()
+        return observation
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Have a trained RL agent play Aliens and store winning runs.")
+    parser.add_argument(
+        "--model-path",
+        type=str,
+        default=os.path.join("models", "dqn_level{level}.zip"),
+        help="Path to the trained DQN policy. Supports {level} formatting.",
+    )
+    parser.add_argument("--level", type=int, default=0, help="Environment level to load.")
+    parser.add_argument(
+        "--wins",
+        type=int,
+        default=10,
+        help="Number of successful games to collect before stopping.",
+    )
+    parser.add_argument(
+        "--deterministic",
+        action="store_true",
+        help="Use a deterministic policy (no exploration during play).",
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Base random seed for reproducibility.")
+    return parser.parse_args()
+
+
+def run_episode(model: DQN, env: AliensEnvRecorder, *, deterministic: bool) -> Tuple[List[Tuple[list, int]], dict]:
+    """Roll out a single episode and capture the observation-action history."""
+
+    data: List[Tuple[list, int]] = []
+    observation = env.reset()
+    done = False
+    info: dict = {}
+
+    while not done:
+        encoded_obs = encode_observation(observation)
+        action, _ = model.predict(encoded_obs, deterministic=deterministic)
+        int_action = int(action)
+        data.append((observation, int_action))
+        observation, _, done, info = env.step(int_action)
+
+    return data, info
+
+
+def main() -> None:
+    args = parse_args()
+    model_path = args.model_path.format(level=args.level)
+
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(
+            f"Could not find trained model at '{model_path}'. "
+            "Run train_rl_agent.py to create it."
+        )
+
+    set_global_seeds(args.seed)
+    env = AliensEnvRecorder(level=args.level, render=False)
+
+    try:
+        model = DQN.load(model_path, print_system_info=False)
+    except TypeError:
+        model = DQN.load(model_path)
+
+    wins = 0
+    attempts = 0
+
+    while wins < args.wins:
+        attempts += 1
+        data, info = run_episode(model, env, deterministic=args.deterministic)
+        message = info.get("message", "")
+
+        if message.endswith("You win."):
+            output_path = os.path.join(env.log_folder, "data.pkl")
+            with open(output_path, "wb") as f:
+                pickle.dump(data, f)
+            wins += 1
+            print(
+                f"Win {wins}/{args.wins}: saved trajectory to '{output_path}'. "
+                f"Attempts so far: {attempts}."
+            )
+        else:
+            print(f"Attempt {attempts} ended without a win: '{message}'")
+
+    print(f"Collected {wins} winning games in {attempts} attempts.")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_rl.py
+++ b/test_rl.py
@@ -1,0 +1,137 @@
+"""Evaluate a trained Stable-Baselines3 agent in the Aliens environment.
+
+This utility complements ``train_rl_agent.py`` by loading a saved DQN policy
+and letting it play a configurable number of episodes.  Typical usage::
+
+    python test_rl.py --level 0 --model-path models/dqn_level{level}.zip --episodes 10
+
+The script prints the episodic reward, number of environment steps, and the
+terminal ``info['message']`` for each run.  Use ``--render`` if you want the
+environment to dump PNG frames to ``figs/`` during evaluation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from statistics import mean, pstdev
+from typing import Optional
+
+from train_rl_agent import AliensGymWrapper, set_global_seeds
+
+try:  # Stable-Baselines3 is required to load and run the trained policy.
+    from stable_baselines3 import DQN
+except ImportError as exc:  # pragma: no cover - more informative error message.
+    raise ImportError(
+        "stable-baselines3 is required. Install the optional dependencies with"
+        " `pip install -r requirements.txt`."
+    ) from exc
+
+
+def run_episode(
+    model: DQN,
+    env: AliensGymWrapper,
+    *,
+    deterministic: bool,
+    seed: Optional[int] = None,
+) -> tuple[float, int, dict]:
+    """Roll out a single episode and return the total reward, steps, and info."""
+
+    obs, _ = env.reset(seed=seed)
+    done = False
+    total_reward = 0.0
+    steps = 0
+    info: dict = {}
+
+    while not done:
+        action, _ = model.predict(obs, deterministic=deterministic)
+        obs, reward, terminated, truncated, info = env.step(action)
+        done = bool(terminated or truncated)
+        total_reward += float(reward)
+        steps += 1
+
+    return total_reward, steps, info
+
+
+def parse_args(args: Optional[list[str]] = None) -> argparse.Namespace:
+    """Parse command-line arguments for RL agent evaluation."""
+
+    parser = argparse.ArgumentParser(
+        description="Evaluate a Stable-Baselines3 DQN agent on the Aliens environment.")
+    parser.add_argument(
+        "--model-path",
+        type=str,
+        default=os.path.join("models", "dqn_level{level}.zip"),
+        help="Path to the saved DQN .zip file. Supports {level} formatting.",
+    )
+    parser.add_argument("--level", type=int, default=0, help="Environment level to evaluate.")
+    parser.add_argument("--episodes", type=int, default=5, help="Number of evaluation episodes to run.")
+    parser.add_argument(
+        "--deterministic",
+        action="store_true",
+        help="Use a deterministic policy instead of sampling from the Q-values.",
+    )
+    parser.add_argument(
+        "--render",
+        action="store_true",
+        help="Enable rendering during evaluation (writes PNGs to figs/).",
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Base random seed for reproducibility.")
+    return parser.parse_args(args)
+
+
+def main() -> None:
+    args = parse_args()
+    model_path = args.model_path.format(level=args.level)
+
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(
+            f"Could not find trained model at '{model_path}'. "
+            "Run train_rl_agent.py to create it."
+        )
+
+    set_global_seeds(args.seed)
+    env = AliensGymWrapper(level=args.level, render=args.render)
+
+    try:
+        # ``print_system_info`` is only available in SB3 >= 2.1.0.
+        model = DQN.load(model_path, print_system_info=False)
+    except TypeError:
+        model = DQN.load(model_path)
+
+    episode_rewards: list[float] = []
+    step_counts: list[int] = []
+
+    for episode in range(args.episodes):
+        # Derive a deterministic seed for each episode for reproducibility while
+        # still exploring different trajectories when ``--deterministic`` is off.
+        total_reward, steps, info = run_episode(
+            model,
+            env,
+            deterministic=args.deterministic,
+            seed=args.seed + episode,
+        )
+        episode_rewards.append(total_reward)
+        step_counts.append(steps)
+        message = info.get("message", "")
+        print(
+            f"Episode {episode + 1}/{args.episodes}: reward={total_reward:.2f}, "
+            f"steps={steps}, message='{message}'"
+        )
+
+    env.close()
+
+    if episode_rewards:
+        avg_reward = mean(episode_rewards)
+        reward_std = pstdev(episode_rewards) if len(episode_rewards) > 1 else 0.0
+        avg_steps = mean(step_counts)
+        print(
+            "Summary: "
+            f"reward_mean={avg_reward:.2f}, reward_std={reward_std:.2f}, "
+            f"avg_steps={avg_steps:.1f}"
+        )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/train_rl_agent.py
+++ b/train_rl_agent.py
@@ -1,50 +1,91 @@
-"""Train a deep Q-learning agent for the Aliens environment.
+"""Train a reinforcement learning agent for the Aliens environment.
 
-This module inspects :mod:`env` to extract the discrete game mechanics and
-implements a light-weight Deep Q-Network (DQN) trainer using only NumPy and the
-standard library.  The environment exposes a grid of categorical entities
-(`wall`, `alien`, `bomb`, etc.), a discrete action space (no-op, move left,
-move right, shoot), and deterministic physics aside from alien bomb drops.
+This script relies on the `stable-baselines3`_ implementation of Deep
+Q-Networks (DQN) instead of the hand-written NumPy agent that previously lived
+in this repository.  The environment defined in :mod:`env` exposes a rich grid
+world with deterministic dynamics and a discrete action space.  Here we wrap it
+as a `Gymnasium <https://gymnasium.farama.org/>`_ environment so that it can be
+used directly with third-party reinforcement learning packages.
 
-The agent learns from self-play by interacting with :class:`env.AliensEnv` and
-storing transitions in a replay buffer.  Each observation is converted into a
-binary feature map describing the presence of every entity on the grid along
-with a handful of high-level summary statistics (avatar position, nearest
-threat distance, remaining portals).  A small fully-connected neural network is
-implemented directly in NumPy to predict Q-values.  Training uses mini-batch
-TD(0) updates with a slowly-updated target network for stability.
+Quick start
+-----------
+1. Install the dependencies::
 
-Example
--------
-    $ python train_rl_agent.py --level 0 --episodes 2000 --render-eval
+       pip install -r requirements.txt
 
-The script will periodically print progress, evaluate the greedy policy, and
-save the learned parameters under ``models/dqn_level0.npz`` by default.
+   ``requirements.txt`` now includes ``stable-baselines3`` and
+   ``gymnasium``.  These packages pull in PyTorch and other prerequisites
+   automatically.
 
-Note
-----
-The implementation avoids third-party deep learning frameworks so that it can
-run in restricted environments (only NumPy and scikit-learn are dependencies of
-this repository).  The NumPy-based neural network supports saving/loading so
-that the trained agent can later be deployed for inference in ``test.py`` or a
-custom evaluation script.
+2. Launch training (saving the model under ``models/``)::
+
+       python train_rl_agent.py --level 0 --total-timesteps 200000
+
+   During training Stable-Baselines3 logs progress to stdout.  The final model
+   checkpoint is written to ``models/dqn_level0`` (or the path supplied via
+   ``--save-path``).
+
+3. (Optional) Run evaluation episodes and periodic checkpoints without
+   generating PNG renders::
+
+       python train_rl_agent.py --level 1 --total-timesteps 500000 \
+           --eval-frequency 10000 --eval-episodes 10 --checkpoint-frequency 50000
+
+   Evaluation always runs headlessly to avoid the expensive PNG rendering that
+   :class:`env.AliensEnv` performs when ``render=True``.
+
+4. Train on GPU by pointing Stable-Baselines3 at your CUDA device::
+
+       python train_rl_agent.py --device cuda
+
+   ``cuda`` automatically selects the default CUDA device.  You can also supply
+   ``cuda:1`` (or similar) to target a specific GPU, or leave the default of
+   ``auto`` to let Stable-Baselines3 pick the best available accelerator.
+
+The resulting policy can be loaded with ``stable_baselines3.DQN.load`` and used
+for inference inside ``play.py``/``test.py`` or custom evaluation scripts.
+
+.. _stable-baselines3: https://stable-baselines3.readthedocs.io/
 """
+
 from __future__ import annotations
 
 import argparse
-import math
 import os
 import random
-from collections import deque
 from dataclasses import dataclass
-from typing import Deque, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Callable, Optional, Sequence
 
 import numpy as np
 
 from env import AliensEnv
 
+try:  # Third-party RL ecosystem imports.
+    import gymnasium as gym
+    from gymnasium import spaces
+except ImportError as exc:  # pragma: no cover - helpful runtime message.
+    raise ImportError(
+        "Gymnasium is required. Install the optional dependencies with"
+        " `pip install -r requirements.txt`."
+    ) from exc
 
-ENTITY_CHANNELS: Tuple[str, ...] = (
+try:
+    from stable_baselines3 import DQN
+    from stable_baselines3.common.callbacks import CallbackList, CheckpointCallback, EvalCallback
+    from stable_baselines3.common.utils import set_random_seed
+    from stable_baselines3.common.vec_env import DummyVecEnv, VecMonitor
+except ImportError as exc:  # pragma: no cover - helpful runtime message.
+    raise ImportError(
+        "stable-baselines3 is required. Install the optional dependencies with"
+        " `pip install -r requirements.txt`."
+    ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Observation encoding helpers (ported from the original NumPy agent)
+# ---------------------------------------------------------------------------
+
+ENTITY_CHANNELS: tuple[str, ...] = (
     "wall",
     "base",
     "portalSlow",
@@ -54,29 +95,20 @@ ENTITY_CHANNELS: Tuple[str, ...] = (
     "bomb",
     "avatar",
 )
-ENTITY_INDEX: Dict[str, int] = {name: idx for idx, name in enumerate(ENTITY_CHANNELS)}
+ENTITY_INDEX = {name: idx for idx, name in enumerate(ENTITY_CHANNELS)}
+EXTRA_FEATURE_COUNT = 7
 
 
 def set_global_seeds(seed: int) -> None:
     """Seed every source of randomness used by the trainer."""
+
     random.seed(seed)
     np.random.seed(seed)
+    set_random_seed(seed)
 
 
 def encode_observation(obs: Sequence[Sequence[Sequence[str]]]) -> np.ndarray:
-    """Convert the nested list observation into a feature vector.
-
-    The base encoding is an 8-channel binary image where each channel indicates
-    the presence of one entity type at every grid coordinate.  To give the
-    learner a sense of global structure, several aggregate statistics are
-    appended:
-
-    * Avatar x/y position (normalized to [-1, 1]).
-    * Count of aliens and bombs (scaled by grid size).
-    * Manhattan distance from the avatar to the nearest alien and bomb
-      (normalized by grid perimeter).
-    * Fraction of portals still active (derived from the observation).
-    """
+    """Convert the nested list observation into a feature vector."""
 
     height = len(obs)
     width = len(obs[0]) if height else 0
@@ -84,8 +116,8 @@ def encode_observation(obs: Sequence[Sequence[Sequence[str]]]) -> np.ndarray:
 
     avatar_x, avatar_y = 0, 0
     portals = 0
-    alien_positions: List[Tuple[int, int]] = []
-    bomb_positions: List[Tuple[int, int]] = []
+    alien_positions: list[tuple[int, int]] = []
+    bomb_positions: list[tuple[int, int]] = []
 
     for y in range(height):
         for x in range(width):
@@ -124,7 +156,6 @@ def encode_observation(obs: Sequence[Sequence[Sequence[str]]]) -> np.ndarray:
     else:
         bomb_dist_norm = 1.0
 
-    # Estimate active portals by counting portal tiles that still contain the portal.
     portal_fraction = portals / grid_size
 
     extras = np.array(
@@ -143,339 +174,214 @@ def encode_observation(obs: Sequence[Sequence[Sequence[str]]]) -> np.ndarray:
     return np.concatenate([grid.reshape(-1), extras], axis=0)
 
 
+# ---------------------------------------------------------------------------
+# Gymnasium wrapper
+# ---------------------------------------------------------------------------
+
+
+class AliensGymWrapper(gym.Env):
+    """Expose :class:`env.AliensEnv` through the Gymnasium API."""
+
+    metadata = {"render_modes": ["rgb_array"], "render_fps": 15}
+
+    def __init__(self, level: int, render: bool = False):
+        super().__init__()
+        self._level = level
+        self._render = render
+        self._env = AliensEnv(level=level, render=render)
+
+        sample_obs = encode_observation(self._env.reset())
+        feature_dim = sample_obs.shape[0]
+
+        low = np.zeros(feature_dim, dtype=np.float32)
+        high = np.ones(feature_dim, dtype=np.float32)
+        # Avatar coordinates are normalised to [-1, 1].
+        low[-EXTRA_FEATURE_COUNT] = -1.0
+        low[-EXTRA_FEATURE_COUNT + 1] = -1.0
+        high[-EXTRA_FEATURE_COUNT] = 1.0
+        high[-EXTRA_FEATURE_COUNT + 1] = 1.0
+
+        self.observation_space = spaces.Box(low=low, high=high, dtype=np.float32)
+        self.action_space = spaces.Discrete(len(self._env.action_space))
+
+    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
+        obs = encode_observation(self._env.reset())
+        return obs.astype(np.float32), {}
+
+    def step(self, action: int):
+        obs, reward, done, info = self._env.step(int(action))
+        encoded = encode_observation(obs).astype(np.float32)
+        terminated = bool(done)
+        truncated = False
+        return encoded, float(reward), terminated, truncated, info
+
+    def render(self):
+        if not self._render:
+            raise RuntimeError(
+                "Rendering was disabled. Re-create the environment with render=True."
+            )
+        # The underlying environment writes PNG files when render=True.
+        return None
+
+    def close(self):
+        # Nothing to clean up: AliensEnv writes images to disk directly.
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Training utilities
+# ---------------------------------------------------------------------------
+
+
 @dataclass
-class Transition:
-    state: np.ndarray
-    action: int
-    reward: float
-    next_state: np.ndarray
-    done: bool
+class TrainingConfig:
+    level: int
+    total_timesteps: int
+    learning_rate: float
+    buffer_size: int
+    batch_size: int
+    train_freq: int
+    gradient_steps: int
+    gamma: float
+    target_update_interval: int
+    exploration_fraction: float
+    exploration_final_eps: float
+    learning_starts: int
+    verbose: int
+    tensorboard_log: Optional[str]
+    seed: int
+    eval_frequency: int
+    eval_episodes: int
+    checkpoint_frequency: int
+    save_path: str
+    log_interval: int
+    device: str
 
 
-class ReplayBuffer:
-    """Experience replay with a fixed maximum capacity."""
+def make_env(level: int, render: bool, seed: int) -> Callable[[], gym.Env]:
+    """Factory to create wrapped environments with deterministic seeding."""
 
-    def __init__(self, capacity: int) -> None:
-        self.capacity = capacity
-        self.buffer: Deque[Transition] = deque(maxlen=capacity)
+    def _init() -> gym.Env:
+        env = AliensGymWrapper(level=level, render=render)
+        env.reset(seed=seed)
+        return env
 
-    def push(self, transition: Transition) -> None:
-        self.buffer.append(transition)
-
-    def sample(self, batch_size: int) -> List[Transition]:
-        return random.sample(self.buffer, batch_size)
-
-    def __len__(self) -> int:
-        return len(self.buffer)
+    return _init
 
 
-class QNetwork:
-    """Simple fully-connected neural network implemented with NumPy."""
+def train(config: TrainingConfig) -> None:
+    """Train a DQN agent using Stable-Baselines3."""
 
-    def __init__(self, input_dim: int, action_dim: int, hidden: Sequence[int], lr: float = 1e-3,
-                 weight_scale: float = 0.02) -> None:
-        layer_sizes = [input_dim, *hidden, action_dim]
-        self.weights: List[np.ndarray] = []
-        self.biases: List[np.ndarray] = []
-        for in_dim, out_dim in zip(layer_sizes[:-1], layer_sizes[1:]):
-            w = np.random.randn(in_dim, out_dim).astype(np.float32) * weight_scale
-            b = np.zeros(out_dim, dtype=np.float32)
-            self.weights.append(w)
-            self.biases.append(b)
-        self.lr = lr
+    os.makedirs(os.path.dirname(config.save_path), exist_ok=True)
 
-    def forward(self, x: np.ndarray) -> Tuple[np.ndarray, List[Tuple[np.ndarray, np.ndarray]]]:
-        activations: List[Tuple[np.ndarray, np.ndarray]] = []
-        out = x
-        for idx, (w, b) in enumerate(zip(self.weights, self.biases)):
-            z = out @ w + b
-            activations.append((out, z))
-            if idx < len(self.weights) - 1:
-                out = np.maximum(z, 0.0)
-            else:
-                out = z
-        return out, activations
+    set_global_seeds(config.seed)
 
-    def predict(self, x: np.ndarray) -> np.ndarray:
-        out, _ = self.forward(x)
-        return out
+    eval_env: Optional[VecMonitor] = None
+    train_env: Optional[VecMonitor] = None
+    try:
+        train_vec = DummyVecEnv([make_env(config.level, render=False, seed=config.seed)])
+        train_vec.seed(config.seed)
+        train_env = VecMonitor(train_vec)
+        train_env.reset()
 
-    def update(self, states: np.ndarray, actions: np.ndarray, targets: np.ndarray) -> float:
-        q_values, activations = self.forward(states)
-        batch_size = states.shape[0]
+        callbacks = []
 
-        chosen_q = q_values[np.arange(batch_size), actions]
-        td_error = chosen_q - targets
-        loss = float(0.5 * np.mean(td_error ** 2))
-
-        grad_output = np.zeros_like(q_values)
-        grad_output[np.arange(batch_size), actions] = td_error / batch_size
-
-        grad = grad_output
-        for layer in reversed(range(len(self.weights))):
-            inputs, pre_act = activations[layer]
-            dW = inputs.T @ grad
-            db = np.sum(grad, axis=0)
-
-            # Gradient descent step
-            self.weights[layer] -= self.lr * dW.astype(np.float32)
-            self.biases[layer] -= self.lr * db.astype(np.float32)
-
-            if layer > 0:
-                prev_inputs, prev_pre_act = activations[layer - 1]
-                grad = grad @ self.weights[layer].T
-                grad = grad * (prev_pre_act > 0)
-            else:
-                # No further layers; break after computing gradient for input layer.
-                break
-
-        return loss
-
-    def copy_from(self, other: "QNetwork") -> None:
-        for idx in range(len(self.weights)):
-            self.weights[idx][...] = other.weights[idx]
-            self.biases[idx][...] = other.biases[idx]
-
-    def save(self, path: str) -> None:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        np.savez(path, *self.weights, *self.biases, allow_pickle=False)
-
-    @classmethod
-    def load(cls, path: str, input_dim: int, action_dim: int, hidden: Sequence[int], lr: float) -> "QNetwork":
-        network = cls(input_dim, action_dim, hidden, lr)
-        data = np.load(path)
-        total_layers = len(network.weights)
-        for idx in range(total_layers):
-            network.weights[idx][...] = data[f'arr_{idx}']
-            network.biases[idx][...] = data[f'arr_{idx + total_layers}']
-        return network
-
-
-class DQNAgent:
-    def __init__(
-        self,
-        state_dim: int,
-        action_dim: int,
-        hidden_sizes: Sequence[int] = (256, 256),
-        lr: float = 1e-3,
-        gamma: float = 0.99,
-        epsilon: float = 1.0,
-        epsilon_min: float = 0.05,
-        epsilon_decay: float = 0.995,
-        target_sync_interval: int = 250,
-    ) -> None:
-        self.action_dim = action_dim
-        self.gamma = gamma
-        self.epsilon = epsilon
-        self.epsilon_min = epsilon_min
-        self.epsilon_decay = epsilon_decay
-        self.target_sync_interval = target_sync_interval
-        self.step_count = 0
-
-        self.online_net = QNetwork(state_dim, action_dim, hidden_sizes, lr)
-        self.target_net = QNetwork(state_dim, action_dim, hidden_sizes, lr)
-        self.target_net.copy_from(self.online_net)
-
-    def act(self, state: np.ndarray) -> int:
-        if random.random() < self.epsilon:
-            return random.randrange(self.action_dim)
-        q_values = self.online_net.predict(state[None, :])[0]
-        return int(np.argmax(q_values))
-
-    def decay_epsilon(self) -> None:
-        self.epsilon = max(self.epsilon * self.epsilon_decay, self.epsilon_min)
-
-    def learn(self, buffer: ReplayBuffer, batch_size: int) -> Optional[float]:
-        if len(buffer) < batch_size:
-            return None
-        transitions = buffer.sample(batch_size)
-        states = np.stack([t.state for t in transitions])
-        actions = np.array([t.action for t in transitions], dtype=np.int64)
-        rewards = np.array([t.reward for t in transitions], dtype=np.float32)
-        next_states = np.stack([t.next_state for t in transitions])
-        dones = np.array([t.done for t in transitions], dtype=np.float32)
-
-        next_q = self.target_net.predict(next_states)
-        max_next_q = np.max(next_q, axis=1)
-        targets = rewards + self.gamma * (1.0 - dones) * max_next_q
-
-        loss = self.online_net.update(states, actions, targets)
-
-        self.step_count += 1
-        if self.step_count % self.target_sync_interval == 0:
-            self.target_net.copy_from(self.online_net)
-
-        return loss
-
-    def save(self, path: str) -> None:
-        self.online_net.save(path)
-
-
-def run_episode(
-    env: AliensEnv,
-    agent: DQNAgent,
-    buffer: ReplayBuffer,
-    max_steps: int,
-    gamma: float,
-    batch_size: int,
-) -> Tuple[float, int]:
-    obs = env.reset()
-    state = encode_observation(obs)
-    total_reward = 0.0
-
-    for step in range(max_steps):
-        action = agent.act(state)
-        next_obs, reward, done, _ = env.step(action)
-        next_state = encode_observation(next_obs)
-
-        buffer.push(Transition(state, action, reward, next_state, done))
-        loss = agent.learn(buffer, batch_size)
-        if loss is not None and math.isnan(loss):
-            raise RuntimeError("Loss became NaN; try lowering the learning rate or adjusting features.")
-
-        total_reward += reward
-        state = next_state
-
-        if done:
-            break
-
-    agent.decay_epsilon()
-    return total_reward, step + 1
-
-
-def evaluate_agent(env: AliensEnv, agent: DQNAgent, episodes: int, max_steps: int) -> Tuple[float, float]:
-    """Run deterministic evaluations (epsilon=0) and report stats."""
-    prev_epsilon = agent.epsilon
-    agent.epsilon = 0.0
-    rewards = []
-    lengths = []
-    for _ in range(episodes):
-        obs = env.reset()
-        state = encode_observation(obs)
-        total_reward = 0.0
-        for step in range(max_steps):
-            action = agent.act(state)
-            next_obs, reward, done, _ = env.step(action)
-            state = encode_observation(next_obs)
-            total_reward += reward
-            if done:
-                break
-        rewards.append(total_reward)
-        lengths.append(step + 1)
-    agent.epsilon = prev_epsilon
-    return float(np.mean(rewards)), float(np.mean(lengths))
-
-
-def train(
-    level: int,
-    episodes: int,
-    buffer_capacity: int,
-    batch_size: int,
-    max_steps: int,
-    hidden_sizes: Sequence[int],
-    lr: float,
-    gamma: float,
-    epsilon: float,
-    epsilon_min: float,
-    epsilon_decay: float,
-    target_sync: int,
-    seed: int,
-    eval_interval: int,
-    eval_episodes: int,
-    render_eval: bool,
-    save_path: str,
-) -> None:
-    set_global_seeds(seed)
-    env = AliensEnv(level=level, render=False)
-    eval_env = AliensEnv(level=level, render=render_eval)
-
-    sample_state = encode_observation(env.reset())
-    agent = DQNAgent(
-        state_dim=sample_state.shape[0],
-        action_dim=len(env.action_space),
-        hidden_sizes=hidden_sizes,
-        lr=lr,
-        gamma=gamma,
-        epsilon=epsilon,
-        epsilon_min=epsilon_min,
-        epsilon_decay=epsilon_decay,
-        target_sync_interval=target_sync,
-    )
-
-    buffer = ReplayBuffer(buffer_capacity)
-
-    for episode in range(1, episodes + 1):
-        reward, steps = run_episode(env, agent, buffer, max_steps, gamma, batch_size)
-
-        if episode % eval_interval == 0:
-            avg_reward, avg_len = evaluate_agent(eval_env, agent, eval_episodes, max_steps)
-            print(
-                f"Episode {episode:05d} | epsilon={agent.epsilon:.3f} | "
-                f"train_reward={reward:.2f} | steps={steps} | "
-                f"eval_reward={avg_reward:.2f} | eval_len={avg_len:.1f}"
+        if config.eval_frequency > 0:
+            eval_vec = DummyVecEnv(
+                [make_env(config.level, render=False, seed=config.seed + 1)]
             )
-        else:
-            print(
-                f"Episode {episode:05d} | epsilon={agent.epsilon:.3f} | "
-                f"train_reward={reward:.2f} | steps={steps}"
+            eval_vec.seed(config.seed + 1)
+            eval_env = VecMonitor(eval_vec)
+            eval_env.reset()
+            best_model_dir = os.path.join(os.path.dirname(config.save_path), "best")
+            os.makedirs(best_model_dir, exist_ok=True)
+            eval_callback = EvalCallback(
+                eval_env,
+                best_model_save_path=best_model_dir,
+                log_path=best_model_dir,
+                eval_freq=config.eval_frequency,
+                n_eval_episodes=config.eval_episodes,
+                deterministic=True,
+                render=False,
             )
+            callbacks.append(eval_callback)
 
-    agent.save(save_path)
-    print(f"Saved trained agent to {save_path}")
+        if config.checkpoint_frequency > 0:
+            checkpoint_dir = os.path.join(os.path.dirname(config.save_path), "checkpoints")
+            os.makedirs(checkpoint_dir, exist_ok=True)
+            checkpoint_callback = CheckpointCallback(
+                save_freq=config.checkpoint_frequency,
+                save_path=checkpoint_dir,
+                name_prefix=f"dqn_level{config.level}",
+            )
+            callbacks.append(checkpoint_callback)
+
+        model = DQN(
+            "MlpPolicy",
+            train_env,
+            learning_rate=config.learning_rate,
+            buffer_size=config.buffer_size,
+            learning_starts=config.learning_starts,
+            batch_size=config.batch_size,
+            train_freq=config.train_freq,
+            gradient_steps=config.gradient_steps,
+            gamma=config.gamma,
+            target_update_interval=config.target_update_interval,
+            exploration_fraction=config.exploration_fraction,
+            exploration_final_eps=config.exploration_final_eps,
+            verbose=config.verbose,
+            tensorboard_log=config.tensorboard_log,
+            device=config.device,
+        )
+
+        callback = CallbackList(callbacks) if callbacks else None
+        model.learn(
+            total_timesteps=config.total_timesteps,
+            log_interval=config.log_interval,
+            callback=callback,
+        )
+
+        model.save(config.save_path)
+        print(f"Saved trained model to {config.save_path}")
+    finally:
+        if eval_env is not None:
+            eval_env.close()
+        if train_env is not None:
+            train_env.close()
 
 
 def parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Train a DQN agent for Aliens.")
+    parser = argparse.ArgumentParser(description="Train a DQN agent for Aliens using Stable-Baselines3.")
     parser.add_argument("--level", type=int, default=0, help="Environment level to train on.")
-    parser.add_argument("--episodes", type=int, default=1500, help="Number of training episodes.")
-    parser.add_argument("--buffer-capacity", type=int, default=20000, help="Replay buffer size.")
-    parser.add_argument("--batch-size", type=int, default=64, help="Mini-batch size for updates.")
-    parser.add_argument("--max-steps", type=int, default=2000, help="Maximum steps per episode.")
-    parser.add_argument(
-        "--hidden-sizes",
-        type=lambda s: tuple(int(x) for x in s.split(",")),
-        default="256,256",
-        help="Comma-separated hidden layer sizes for the Q-network.",
-    )
-    parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate for the Q-network.")
+    parser.add_argument("--total-timesteps", type=int, default=200_000, help="Total environment steps to collect.")
+    parser.add_argument("--learning-rate", type=float, default=1e-4, help="Optimizer learning rate.")
+    parser.add_argument("--buffer-size", type=int, default=100_000, help="Replay buffer size.")
+    parser.add_argument("--batch-size", type=int, default=64, help="Mini-batch size.")
+    parser.add_argument("--train-freq", type=int, default=4, help="Frequency of gradient updates in steps.")
+    parser.add_argument("--gradient-steps", type=int, default=1, help="Gradient steps to run after each rollout.")
     parser.add_argument("--gamma", type=float, default=0.99, help="Discount factor.")
-    parser.add_argument("--epsilon", type=float, default=1.0, help="Initial epsilon for exploration.")
-    parser.add_argument("--epsilon-min", type=float, default=0.05, help="Minimum epsilon.")
+    parser.add_argument("--target-update-interval", type=int, default=10_000, help="Steps between target network syncs.")
+    parser.add_argument("--exploration-fraction", type=float, default=0.1, help="Fraction of training for epsilon decay.")
+    parser.add_argument("--exploration-final-eps", type=float, default=0.02, help="Final epsilon after decay.")
+    parser.add_argument("--learning-starts", type=int, default=1_000, help="How many steps to collect before updates.")
+    parser.add_argument("--verbose", type=int, default=1, choices=[0, 1, 2], help="Stable-Baselines3 verbosity level.")
+    parser.add_argument("--tensorboard-log", type=str, default=None, help="Optional TensorBoard log directory.")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed for reproducibility.")
+    parser.add_argument("--eval-frequency", type=int, default=0, help="How often (in steps) to run evaluation. 0 disables it.")
+    parser.add_argument("--eval-episodes", type=int, default=5, help="Number of evaluation episodes per run.")
+    parser.add_argument("--checkpoint-frequency", type=int, default=0, help="How often (in steps) to save checkpoints. 0 disables it.")
+    parser.add_argument("--save-path", type=str, default=os.path.join("models", "dqn_level{level}"), help="Where to save the trained policy.")
+    parser.add_argument("--log-interval", type=int, default=100, help="Logging interval passed to Stable-Baselines3.")
     parser.add_argument(
-        "--epsilon-decay",
-        type=float,
-        default=0.995,
-        help="Multiplicative epsilon decay applied after each episode.",
-    )
-    parser.add_argument(
-        "--target-sync",
-        type=int,
-        default=250,
-        help="Number of gradient steps between target network synchronizations.",
-    )
-    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
-    parser.add_argument(
-        "--eval-interval",
-        type=int,
-        default=50,
-        help="How often to run policy evaluation episodes.",
-    )
-    parser.add_argument(
-        "--eval-episodes",
-        type=int,
-        default=5,
-        help="Number of deterministic evaluation runs per interval.",
-    )
-    parser.add_argument(
-        "--render-eval",
-        action="store_true",
-        help="Render frames during evaluation runs (useful for debugging).",
-    )
-    parser.add_argument(
-        "--save-path",
+        "--device",
         type=str,
-        default=os.path.join("models", "dqn_level{level}.npz"),
-        help="Destination path for the trained weights.",
+        default="auto",
+        help=(
+            "Computation device passed to Stable-Baselines3 (e.g. 'auto', 'cpu', 'cuda', 'cuda:0')."
+        ),
     )
     return parser.parse_args(args)
 
@@ -483,26 +389,32 @@ def parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
     save_path = args.save_path.format(level=args.level)
-    train(
+    config = TrainingConfig(
         level=args.level,
-        episodes=args.episodes,
-        buffer_capacity=args.buffer_capacity,
+        total_timesteps=args.total_timesteps,
+        learning_rate=args.learning_rate,
+        buffer_size=args.buffer_size,
         batch_size=args.batch_size,
-        max_steps=args.max_steps,
-        hidden_sizes=args.hidden_sizes,
-        lr=args.lr,
+        train_freq=args.train_freq,
+        gradient_steps=args.gradient_steps,
         gamma=args.gamma,
-        epsilon=args.epsilon,
-        epsilon_min=args.epsilon_min,
-        epsilon_decay=args.epsilon_decay,
-        target_sync=args.target_sync,
+        target_update_interval=args.target_update_interval,
+        exploration_fraction=args.exploration_fraction,
+        exploration_final_eps=args.exploration_final_eps,
+        learning_starts=args.learning_starts,
+        verbose=args.verbose,
+        tensorboard_log=args.tensorboard_log,
         seed=args.seed,
-        eval_interval=args.eval_interval,
+        eval_frequency=args.eval_frequency,
         eval_episodes=args.eval_episodes,
-        render_eval=args.render_eval,
+        checkpoint_frequency=args.checkpoint_frequency,
         save_path=save_path,
+        log_interval=args.log_interval,
+        device=args.device,
     )
+    train(config)
 
 
 if __name__ == "__main__":
     main()
+

--- a/train_rl_agent_cpu.py
+++ b/train_rl_agent_cpu.py
@@ -1,0 +1,84 @@
+"""Train the Aliens reinforcement learning agent on CPU with Stable-Baselines3.
+
+This script mirrors the GPU training workflow implemented in
+:mod:`train_rl_agent`, but pins the computation device to the host CPU by
+default.  It wraps :class:`env.AliensEnv` inside the Gymnasium API, encodes the
+observations into feature vectors and then leverages the third-party
+``stable-baselines3`` implementation of DQN to optimise a policy.
+
+Usage
+-----
+1. Install the project dependencies (they include ``gymnasium`` and
+   ``stable-baselines3``)::
+
+       pip install -r requirements.txt
+
+2. Launch CPU training for a given level.  The device is forced to ``cpu``
+   unless you override it explicitly::
+
+       python train_rl_agent_cpu.py --level 0 --total-timesteps 200000
+
+   You may supply any of the regular hyper-parameters (learning rate,
+   exploration schedule, replay buffer size, etc.).  Checkpoints and metrics are
+   written to the same locations as in the GPU script.
+
+3. Optional: enable periodic evaluation or checkpointing::
+
+       python train_rl_agent_cpu.py --eval-frequency 10000 --eval-episodes 5 \
+           --checkpoint-frequency 50000
+
+   Evaluation environments always run without rendering so the expensive PNG
+   output is avoided.
+
+The resulting policy artefacts are fully compatible with
+``stable_baselines3.DQN.load`` and can be consumed by ``test_rl.py`` or
+``rl_play.py`` for automated evaluation and dataset generation.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from train_rl_agent import TrainingConfig, parse_args as gpu_parse_args, train
+
+
+def parse_args(args: Optional[Sequence[str]] = None):
+    """Parse CLI arguments while defaulting the computation device to CPU."""
+
+    namespace = gpu_parse_args(args)
+    if namespace.device == "auto":
+        namespace.device = "cpu"
+    return namespace
+
+
+def main() -> None:
+    args = parse_args()
+    save_path = args.save_path.format(level=args.level)
+    config = TrainingConfig(
+        level=args.level,
+        total_timesteps=args.total_timesteps,
+        learning_rate=args.learning_rate,
+        buffer_size=args.buffer_size,
+        batch_size=args.batch_size,
+        train_freq=args.train_freq,
+        gradient_steps=args.gradient_steps,
+        gamma=args.gamma,
+        target_update_interval=args.target_update_interval,
+        exploration_fraction=args.exploration_fraction,
+        exploration_final_eps=args.exploration_final_eps,
+        learning_starts=args.learning_starts,
+        verbose=args.verbose,
+        tensorboard_log=args.tensorboard_log,
+        seed=args.seed,
+        eval_frequency=args.eval_frequency,
+        eval_episodes=args.eval_episodes,
+        checkpoint_frequency=args.checkpoint_frequency,
+        save_path=save_path,
+        log_interval=args.log_interval,
+        device=args.device,
+    )
+    train(config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `train_rl_agent_cpu.py`, a CPU-specific entry point that reuses the Stable-Baselines3 workflow and defaults to the host processor
- document installation and usage details in the new script to mirror the GPU trainer without rendering overhead

## Testing
- python -m compileall train_rl_agent.py train_rl_agent_cpu.py

------
https://chatgpt.com/codex/tasks/task_e_68d4a647d85c832891461127511b59de