### PR TITLE
Refine supervised training workflow into baseline and enhanced phases

### DIFF
--- a/docs/run_train.sh
+++ b/docs/run_train.sh
@@ -12,7 +12,7 @@ echo "== Step 1: reset stale artefacts =="
 python reset_experiment_data.py --targets logs models figs analysis --yes
 
 echo "== Step 2: ensure helper directories exist =="
-mkdir -p logs models analysis/figures figs
+mkdir -p logs models analysis/baseline_figures analysis/enhanced_figures figs
 
 echo "== Step 3: train RL specialists for levels 0-4 =="
 python train_rl_agent.py --level 0 --total-timesteps 3500000 --num-envs auto
@@ -28,18 +28,32 @@ python rl_play.py --level 2 --wins 100 --deterministic
 python rl_play.py --level 3 --wins 100 --deterministic
 python rl_play.py --level 4 --wins 100 --deterministic
 
-echo "== Step 5: train supervised agents across methods and levels (incl. 'all') =="
-# Default helper trains the required methods over levels 0–4 plus 'all'
-python train_supervised_agents.py --levels 0 1 2 3 4 all --jobs auto
+echo "== Step 5a: train baseline supervised agents (random forest, logistic, gradient boost) =="
+python train_supervised_agents.py --experiments baseline --levels 0 1 2 3 4 all --jobs auto
 
-echo "== Step 6: evaluate trained agents (900 episodes total by default settings) =="
+echo "== Step 5b: train enhanced-feature supervised agents (gradient boost + engineered features) =="
+python train_supervised_agents.py --experiments enhanced --levels 0 1 2 3 4 all --jobs auto
+
+echo "== Step 6a: evaluate baseline agents (900 episodes) =="
 python evaluate_supervised_agents.py \
+  --model-dir models/baseline \
   --episodes 30 \
   --max-steps 2500 \
   --jobs auto \
-  --output analysis/scores.json
+  --output analysis/baseline_scores.json
 
-echo "== Step 7: analyze and export tables/figures =="
-python analyze_scores.py --scores analysis/scores.json --output-dir analysis/figures
+echo "== Step 6b: evaluate enhanced-feature agents (900 episodes) =="
+python evaluate_supervised_agents.py \
+  --model-dir models/enhanced \
+  --episodes 30 \
+  --max-steps 2500 \
+  --jobs auto \
+  --output analysis/enhanced_scores.json
 
-echo "✅ Done. Artifacts are under models/, analysis/, and analysis/figures/"
+echo "== Step 7a: analyze baseline evaluation results =="
+python analyze_scores.py --scores analysis/baseline_scores.json --output-dir analysis/baseline_figures
+
+echo "== Step 7b: analyze enhanced-feature evaluation results =="
+python analyze_scores.py --scores analysis/enhanced_scores.json --output-dir analysis/enhanced_figures
+
+echo "✅ Done. Artifacts are under models/, analysis/baseline_figures/, and analysis/enhanced_figures/"

--- a/learn_random_forest.py
+++ b/learn_random_forest.py
@@ -1,0 +1,92 @@
+"""Train a supervised Aliens agent using Random Forests."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+from sklearn.ensemble import RandomForestClassifier
+
+from supervised import train_and_save_model
+
+
+def parse_level(value: str) -> int | str:
+    return value if value == "all" else int(value)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--level", type=parse_level, default=0, help="Level to train on (0-4 or 'all').")
+    parser.add_argument(
+        "--logs",
+        nargs="*",
+        default=None,
+        help="Optional list of log folder names to train on. Overrides automatic discovery.",
+    )
+    parser.add_argument(
+        "--max-logs",
+        type=int,
+        default=150,
+        help="Cap the number of log folders used (mirrors learn.py default of 150).",
+    )
+    parser.add_argument(
+        "--wins-only",
+        action="store_true",
+        help="When discovering logs automatically, only use winning trajectories.",
+    )
+    parser.add_argument("--n-estimators", type=int, default=300, help="Number of trees in the forest.")
+    parser.add_argument("--max-depth", type=int, default=None, help="Maximum depth of each tree.")
+    parser.add_argument(
+        "--min-samples-leaf",
+        type=int,
+        default=1,
+        help="Minimum samples required at a leaf node.",
+    )
+    parser.add_argument("--random-state", type=int, default=7, help="Random seed for reproducibility.")
+    parser.add_argument(
+        "--n-jobs",
+        type=int,
+        default=-1,
+        help="Parallel workers for tree construction (mirrors scikit-learn's n_jobs).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="models",
+        help="Directory to store the trained model bundle.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+
+    estimator = RandomForestClassifier(
+        n_estimators=args.n_estimators,
+        max_depth=args.max_depth,
+        min_samples_leaf=args.min_samples_leaf,
+        random_state=args.random_state,
+        n_jobs=args.n_jobs,
+        verbose=0,
+    )
+
+    train_and_save_model(
+        level=args.level,
+        estimator=estimator,
+        method="random_forest",
+        feature_extractor="extract_binary_features",
+        logs=args.logs,
+        max_logs=args.max_logs,
+        wins_only=args.wins_only,
+        output_dir=args.output_dir,
+        extra_metadata={
+            "n_estimators": args.n_estimators,
+            "max_depth": args.max_depth,
+            "min_samples_leaf": args.min_samples_leaf,
+            "n_jobs": args.n_jobs,
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a dedicated `learn_random_forest.py` wrapper so the legacy random forest baseline participates in the shared supervised training pipeline
- restructure `train_supervised_agents.py` to support explicit baseline and enhanced experiments, including new CLI options and automatic output segregation
- refresh the documentation and orchestration script to describe and execute the two-phase training/evaluation workflow with separate artefacts

## Testing
- python -m compileall learn_random_forest.py train_supervised_agents.py docs/run_train.sh
- python train_supervised_agents.py --levels 0 --experiments baseline enhanced --dry-run


------
https://chatgpt.com/codex/tasks/task_e_68da0d3d53a8832897f0954a611e01a1